### PR TITLE
Retrait des liens vers les markdown geoparquet

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ This repository contains:
 
 ### Using the GeoParquet Optimized Building Layer
 
-- Learn how to use the GeoParquet optimized building layer with Python and GDAL: see [acces-python-gdal.md](docs/en/optimized_building_footprint/acces-python-gdal.md)
-- Visualize the layer using QGIS: see [acces-qgis.md](docs/en/optimized_building_footprint/acces-qgis.md)
+- Learn how to use the GeoParquet optimized building layer with Python and GDAL
+- Visualize the layer using QGIS
 
 ## 📖 Documentation
 

--- a/README_FR.md
+++ b/README_FR.md
@@ -36,13 +36,8 @@ Ce dépôt contient  :
 
 ### Utilisation du GeoParquet de la couche optimisée des bâtiments
 
-- Apprenez à utiliser le GeoParquet de la couche optimisée des bâtiments à l'aide de Python et GDAL.
-- Visualisez la couche à l'aide de QGIS.
-
-*English version:*
-   - [Python & GDAL Access](docs/en/optimized_building_footprint/python-gdal-access.md)
-   - [QGIS Access](docs/en/optimized_building_footprint/qgis-access.md)
-  
+- Apprenez à utiliser le GeoParquet de la couche optimisée des bâtiments à l'aide de Python et GDAL
+- Visualisez la couche à l'aide de QGIS
 
 ## 📖 Documentation
 


### PR DESCRIPTION
La section geoparquet des keyfeature était la seule qui pointait vers les markdown. 